### PR TITLE
Tweak inithook

### DIFF
--- a/overlay/usr/lib/inithooks/bin/odoo.py
+++ b/overlay/usr/lib/inithooks/bin/odoo.py
@@ -51,15 +51,24 @@ def main():
 
     processed_password = CryptContext(['pbkdf2_sha512']).hash(password)
 
-    p = PostgreSQL('TurnkeylinuxExample')
-    p.execute("UPDATE res_users SET password='{}' WHERE id=2".format(
-        processed_password).encode('utf8'))
+    default_db = 'TurnkeylinuxExample'
+    default_db_exists = True
+    try:
+        p = PostgreSQL(default_db)
+        p.execute("UPDATE res_users SET password='{}' WHERE id=2".format(
+            processed_password).encode('utf8'))
+    except subprocess.CalledProcessError as e:
+        default_db_exists = False
+        print(f"Default DB ({default_db}) not found - skipping setting passsword for that")
 
     sys.path.insert(0, '/usr/lib/python3/dist-packages')
     import odoo
     odoo.tools.config.parse_config(['--config=/etc/odoo/odoo.conf'])
     odoo.tools.config.set_admin_password(password)
     odoo.tools.config.save()
+
+    if not default_db_exists:
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/overlay/usr/lib/inithooks/bin/odoo.py
+++ b/overlay/usr/lib/inithooks/bin/odoo.py
@@ -67,6 +67,9 @@ def main():
     odoo.tools.config.set_admin_password(password)
     odoo.tools.config.save()
 
+    # restart odoo to apply updated password
+    subprocess.run(['systemctl', 'restart', 'odoo'])
+
     if not default_db_exists:
         sys.exit(1)
 


### PR DESCRIPTION
This was a quick hack to [assist Landis](https://www.turnkeylinux.org/comment/54662#comment-54662) (a long term and highly valued TurnKey user and contributor).

Note that this change also includes a restart to the `odoo` service. Whilst my testing demonstrated that it was working ok at firstboot, I suspect that there was a potential race condition after I noticed it didn't reliably update the password unless I restarted the service after updating the password (the "Master password" hash is stored in the config file, so it makes sense).

Ideally our [PostgreSQL Inithook module](https://github.com/turnkeylinux/common/blob/master/overlays/pgsql/usr/lib/inithooks/bin/pgsqlconf.py) should be reworked to support optionally not failing, or perhaps just allow it to suppress output.

Part of me would like it to give a return code and/or an error message, so that we didn't need to run it in a `try...except`. But that would probably require modification for all initihooks that leverage the default PostgreSQL one. Another idea, that wouldn't require as much work (so is probably preferable) would be to just allow it to suppress output. That would allow these modifications to still work as intended, but would remove the erroneous "fatal" message when the DB doesn't exist.