### PR TITLE
Update xfonts-75dpi

### DIFF
--- a/plan/main
+++ b/plan/main
@@ -2,6 +2,7 @@
 #include <turnkey/lapp>
 
 odoo-16
+xfonts-75dpi
 wkhtmltopdf
 python3-psycogreen
 


### PR DESCRIPTION
This is a requirment for running and installing wkhtmltopdf (currently not working) another fix must be made to use this instead in the future

https://github.com/odoo/odoo/wiki/Wkhtmltopdf