### PR TITLE
Downgrade wkhtmltopdf

### DIFF
--- a/plan/main
+++ b/plan/main
@@ -3,11 +3,15 @@
 
 odoo-16
 xfonts-75dpi
-wkhtmltopdf
+wget
 python3-psycogreen
 
-adduser             
-postgresql-client   
+adduser
+postgresql-client
 python3
 
 python3-passlib      /* Needed to set admin password */
+
+/* Installing specific version of wkhtmltox for Odoo compatibility */
+wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bookworm_amd64.deb
+dpkg -i wkhtmltox_0.12.6.1-3.bookworm_amd64.deb || apt-get -f install


### PR DESCRIPTION
The latest wkhtml version provided by Debian is incompatible with odoo and probably won't be maintained anymore, the reason is that Odoo os changing the ORM for other ways to manipulated PDFs. Te monkeypatch i found is to use the specific use of this: https://github.com/odoo/odoo/wiki/Wkhtmltopdf specially for Odoo16.0 https://github.com/wkhtmltopdf/packaging/releases/tag/0.12.6.1-3 The problem here is that it is CPU oriented. The main usage here for me has been AMD64, so probably you should also check this for your self

Making this a PR so people can see the main issue, naturally is not a TKL issue but rather than an Odoo Issue, any way im leaving this here for you to be able to check and don't have the need to deep dive in Odoo Documentation, also notices i'll leave this as Draft as this is not an actual FIX but rather dummy code. After release of Version 19.0 i remove this